### PR TITLE
fix: close webcam frame on read failure

### DIFF
--- a/internal/capture/webcam.go
+++ b/internal/capture/webcam.go
@@ -22,12 +22,14 @@ func OpenWebCam() (*WebCam, error) {
 
 // ReadFrame returns a new frame from the webcam
 func (w *WebCam) ReadFrame() (gocv.Mat, error) {
-	img := gocv.NewMat()
-	if ok := w.cam.Read(&img); !ok || img.Empty() {
-		return gocv.Mat{}, errors.New("failed to read frame")
-	}
+        img := gocv.NewMat()
+       if ok := w.cam.Read(&img); !ok || img.Empty() {
+               // Ensure allocated Mat resources are released on error
+               img.Close()
+               return gocv.Mat{}, errors.New("failed to read frame")
+       }
 
-	return img, nil
+       return img, nil
 }
 
 func (w *WebCam) Close() {


### PR DESCRIPTION
## Summary
- ensure WebCam.ReadFrame releases its Mat when frame capture fails to avoid leaks

## Testing
- `go build ./cmd/...` *(fails: Package opencv4 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68aeffea5b60832d82f16b422fe1e94a